### PR TITLE
Add Discord worm simulator skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+*.o
+killswitch
+killswitch_test
+ks_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.14)
+project(DiscordWormSimulator CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+set(CPR_USE_SYSTEM_CURL ON)
+
+# cpr
+FetchContent_Declare(
+  cpr
+  GIT_REPOSITORY https://github.com/libcpr/cpr.git
+  GIT_TAG 1.10.5
+)
+FetchContent_MakeAvailable(cpr)
+
+# nlohmann json
+FetchContent_Declare(
+  json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.11.2
+)
+FetchContent_MakeAvailable(json)
+
+# spdlog
+FetchContent_Declare(
+  spdlog
+  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+  GIT_TAG v1.12.0
+)
+FetchContent_MakeAvailable(spdlog)
+
+# Catch2
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+add_library(worm
+    src/TokenLoader.cpp
+    src/WormLogic.cpp
+    src/RateLimiter.cpp
+    src/Logger.cpp
+    src/KillSwitch.cpp
+)
+
+target_include_directories(worm PUBLIC include)
+
+target_link_libraries(worm PUBLIC cpr::cpr nlohmann_json::nlohmann_json spdlog::spdlog)
+
+add_executable(simulator src/main.cpp)
+target_link_libraries(simulator PRIVATE worm)
+
+# Tests
+enable_testing()
+add_executable(tests
+    tests/TokenLoaderTests.cpp
+    tests/RateLimiterTests.cpp
+    tests/KillSwitchTests.cpp
+    tests/WormLogicTests.cpp
+)
+
+target_link_libraries(tests PRIVATE worm Catch2::Catch2WithMain)
+add_test(NAME allTests COMMAND tests)
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04 AS build
+RUN apt-get update && apt-get install -y git build-essential cmake
+WORKDIR /app
+COPY . .
+RUN cmake -S . -B build && cmake --build build
+
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN pip3 install flask
+COPY --from=build /app/build/simulator /simulator
+COPY tokens.txt /tokens.txt
+COPY stub_server /stub_server
+WORKDIR /
+EXPOSE 5000
+CMD ["/simulator"]
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,57 @@
+# Discord Worm Simulator
+
+Educational C++ project that models worm-like behavior against a stubbed Discord API. **This tool must only be used in isolated lab environments for research and teaching purposes.** No real Discord endpoints are contacted by default.
+
+## Ethical Disclaimer
+Running malware, even in simulated form, carries risk. Use this repository responsibly and only with systems you own or have explicit permission to test. The authors do not condone misuse.
+
+## Build Instructions
+### Requirements
+- C++17 compiler
+- CMake 3.14+
+- Internet access for dependency fetch
+
+### Build & Run
+```bash
+cmake -S . -B build
+cmake --build build
 ```
- __          _____  _____  __  __  _____ ___  _____  _____  
- \ \        / / _ \|  __ \|  \/  |/ ____/ _ \|  __ \|  __ \ 
-  \ \  /\  / / | | | |__) | \  / | |   | | | | |__) | |  | |
-   \ \/  \/ /| | | |  _  /| |\/| | |   | | | |  _  /| |  | |
-    \  /\  / | |_| | | \ \| |  | | |___| |_| | | \ \| |__| |
-     \/  \/   \___/|_|  \_\_|  |_|\_____\___/|_|  \_\_____/  
+
+Start the stub Discord API:
+```bash
+python3 stub_server/server.py
 ```
+
+Run the simulator:
+```bash
+./build/simulator
+```
+
+Create a file named `killswitch` in the working directory to stop execution.
+
+## Docker
+```bash
+docker build -t worm-sim .
+docker run --rm -it -p 5000:5000 worm-sim
+```
+Use another shell inside the container to run the stub server with `python3 /stub_server/server.py`.
+
+## Testing
+```bash
+ctest --test-dir build
+```
+
+## Security Review Notes
+- Uses only standard C++ threading and avoids raw pointers.
+- Network communication targets `http://localhost:5000` and should be monitored.
+- The file-based kill switch is polled; race conditions are mitigated with atomic flags but should be reviewed.
+- No privileged or unsafe system calls are used.
+
+## Extending the Simulator
+- **Jitter/Backoff**: modify `RateLimiter` or insert delays in `WormLogic`.
+- **Custom Payloads**: adjust payload in `WormLogic::processToken`.
+- **Additional Behaviors**: add new modules or extend existing ones following the current style and Doxygen comments.
+
+## Example Tokens
+`tokens.txt` contains placeholder tokens. Replace with test tokens as needed.
+

--- a/include/KillSwitch.hpp
+++ b/include/KillSwitch.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <atomic>
+#include <string>
+#include <thread>
+
+/**
+ * @brief Watches for a file to appear and signals termination.
+ */
+class KillSwitch {
+public:
+    explicit KillSwitch(const std::string& path);
+    ~KillSwitch();
+
+    void start();
+    void stop();
+    bool triggered() const { return triggered_; }
+
+private:
+    void watch();
+    std::string path_;
+    std::atomic<bool> running_{false};
+    std::atomic<bool> triggered_{false};
+    std::thread worker_;
+};
+

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <memory>
+#include <spdlog/spdlog.h>
+
+/**
+ * @brief Wrapper around spdlog for structured logging.
+ */
+class Logger {
+public:
+    static void init();
+    static std::shared_ptr<spdlog::logger>& instance();
+};
+

--- a/include/RateLimiter.hpp
+++ b/include/RateLimiter.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <chrono>
+#include <mutex>
+
+/**
+ * @brief Simple rate limiter based on a fixed interval.
+ */
+class RateLimiter {
+public:
+    /**
+     * @param opsPerSecond Allowed operations per second. Must be >0.
+     */
+    explicit RateLimiter(std::size_t opsPerSecond);
+
+    /**
+     * @brief Acquire permission for the next operation.
+     */
+    void acquire();
+
+private:
+    std::chrono::steady_clock::time_point next_;
+    std::chrono::milliseconds interval_;
+    std::mutex mutex_;
+};
+

--- a/include/TokenLoader.hpp
+++ b/include/TokenLoader.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <string>
+#include <vector>
+
+/**
+ * @brief Loads Discord tokens from a file and validates their format.
+ */
+class TokenLoader {
+public:
+    /**
+     * @param filePath Path to the token file.
+     */
+    explicit TokenLoader(const std::string& filePath);
+
+    /**
+     * @brief Load and validate tokens.
+     * @return Vector of valid tokens.
+     * @throws std::runtime_error if file cannot be read.
+     */
+    std::vector<std::string> load() const;
+
+private:
+    bool isValidToken(const std::string& token) const;
+    std::string path_;
+};
+

--- a/include/WormLogic.hpp
+++ b/include/WormLogic.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "RateLimiter.hpp"
+#include "KillSwitch.hpp"
+
+/**
+ * @brief Simulates basic worm actions against a stubbed Discord API.
+ */
+class WormLogic {
+public:
+    WormLogic(std::vector<std::string> tokens,
+              const std::string& baseUrl,
+              RateLimiter& limiter,
+              KillSwitch& killSwitch);
+
+    /**
+     * @brief Run the worm simulation for all tokens.
+     */
+    void run();
+
+private:
+    void processToken(const std::string& token);
+
+    std::vector<std::string> tokens_;
+    std::string baseUrl_;
+    RateLimiter& limiter_;
+    KillSwitch& killSwitch_;
+};
+

--- a/src/KillSwitch.cpp
+++ b/src/KillSwitch.cpp
@@ -1,0 +1,31 @@
+#include "KillSwitch.hpp"
+#include <chrono>
+#include <filesystem>
+
+KillSwitch::KillSwitch(const std::string& path) : path_(path) {}
+KillSwitch::~KillSwitch() { stop(); }
+
+void KillSwitch::start() {
+    running_ = true;
+    worker_ = std::thread(&KillSwitch::watch, this);
+}
+
+void KillSwitch::stop() {
+    running_ = false;
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+void KillSwitch::watch() {
+    using namespace std::chrono_literals;
+    while (running_) {
+        if (std::filesystem::exists(path_)) {
+            triggered_ = true;
+            running_ = false;
+            break;
+        }
+        std::this_thread::sleep_for(500ms);
+    }
+}
+

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,16 @@
+#include "Logger.hpp"
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+static std::shared_ptr<spdlog::logger> logger;
+
+void Logger::init() {
+    if (!logger) {
+        logger = spdlog::stdout_color_mt("worm");
+        logger->set_pattern("%Y-%m-%d %H:%M:%S %^%l%$ %v");
+    }
+}
+
+std::shared_ptr<spdlog::logger>& Logger::instance() {
+    return logger;
+}
+

--- a/src/RateLimiter.cpp
+++ b/src/RateLimiter.cpp
@@ -1,0 +1,17 @@
+#include "RateLimiter.hpp"
+#include <thread>
+
+RateLimiter::RateLimiter(std::size_t opsPerSecond)
+    : next_(std::chrono::steady_clock::now()),
+      interval_(opsPerSecond ? std::chrono::milliseconds(1000 / opsPerSecond)
+                             : std::chrono::milliseconds(1000)) {}
+
+void RateLimiter::acquire() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    auto now = std::chrono::steady_clock::now();
+    if (now < next_) {
+        std::this_thread::sleep_for(next_ - now);
+    }
+    next_ = std::chrono::steady_clock::now() + interval_;
+}
+

--- a/src/TokenLoader.cpp
+++ b/src/TokenLoader.cpp
@@ -1,0 +1,27 @@
+#include "TokenLoader.hpp"
+#include <fstream>
+#include <regex>
+#include <stdexcept>
+
+TokenLoader::TokenLoader(const std::string& filePath) : path_(filePath) {}
+
+bool TokenLoader::isValidToken(const std::string& token) const {
+    static const std::regex pattern("^[A-Za-z0-9_\\.-]{10,}$");
+    return std::regex_match(token, pattern);
+}
+
+std::vector<std::string> TokenLoader::load() const {
+    std::ifstream file(path_);
+    if (!file) {
+        throw std::runtime_error("Unable to open token file: " + path_);
+    }
+    std::vector<std::string> tokens;
+    std::string line;
+    while (std::getline(file, line)) {
+        if (isValidToken(line)) {
+            tokens.push_back(line);
+        }
+    }
+    return tokens;
+}
+

--- a/src/WormLogic.cpp
+++ b/src/WormLogic.cpp
@@ -1,0 +1,54 @@
+#include "WormLogic.hpp"
+#include "Logger.hpp"
+#include <cpr/cpr.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+WormLogic::WormLogic(std::vector<std::string> tokens,
+                     const std::string& baseUrl,
+                     RateLimiter& limiter,
+                     KillSwitch& killSwitch)
+    : tokens_(std::move(tokens)), baseUrl_(baseUrl), limiter_(limiter), killSwitch_(killSwitch) {}
+
+void WormLogic::run() {
+    for (const auto& token : tokens_) {
+        if (killSwitch_.triggered()) {
+            Logger::instance()->info("Kill switch triggered. Stopping.");
+            break;
+        }
+        processToken(token);
+    }
+}
+
+void WormLogic::processToken(const std::string& token) {
+    Logger::instance()->info("Processing token: {}", token);
+
+    limiter_.acquire();
+    auto loginResp = cpr::Post(cpr::Url{baseUrl_ + "/login"},
+                               cpr::Body{json{{"token", token}}.dump()},
+                               cpr::Header{{"Content-Type", "application/json"}});
+    Logger::instance()->info("Login status: {}", loginResp.status_code);
+
+    limiter_.acquire();
+    auto friendsResp = cpr::Get(cpr::Url{baseUrl_ + "/friends"}, cpr::Parameters{{"token", token}});
+    auto friendsJson = json::parse(friendsResp.text, nullptr, false);
+    if (!friendsJson.is_object()) {
+        Logger::instance()->warn("Invalid friends response");
+        return;
+    }
+
+    for (const auto& friendId : friendsJson["friends"]) {
+        if (killSwitch_.triggered()) {
+            Logger::instance()->info("Kill switch triggered during friend loop.");
+            break;
+        }
+        limiter_.acquire();
+        json payload{{"to", friendId}, {"message", "Hello from simulator"}};
+        cpr::Post(cpr::Url{baseUrl_ + "/dm"},
+                  cpr::Body{payload.dump()},
+                  cpr::Header{{"Content-Type", "application/json"}});
+        Logger::instance()->info("Sent DM to {}", friendId.get<std::string>());
+    }
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,32 @@
+#include "TokenLoader.hpp"
+#include "WormLogic.hpp"
+#include "Logger.hpp"
+#include "RateLimiter.hpp"
+#include "KillSwitch.hpp"
+#include <iostream>
+
+int main() {
+    Logger::init();
+    try {
+        TokenLoader loader("tokens.txt");
+        auto tokens = loader.load();
+        if (tokens.empty()) {
+            Logger::instance()->warn("No valid tokens found.");
+            return 0;
+        }
+
+        RateLimiter limiter(5); // 5 operations per second
+        KillSwitch killSwitch("killswitch");
+        killSwitch.start();
+
+        WormLogic worm(std::move(tokens), "http://localhost:5000", limiter, killSwitch);
+        worm.run();
+
+        killSwitch.stop();
+    } catch (const std::exception& ex) {
+        Logger::instance()->error("Exception: {}", ex.what());
+        return 1;
+    }
+    return 0;
+}
+

--- a/stub_server/server.py
+++ b/stub_server/server.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.post('/login')
+def login():
+    data = request.get_json() or {}
+    token = data.get('token', '')
+    if token:
+        return jsonify({'status': 'ok'}), 200
+    return jsonify({'status': 'error'}), 400
+
+@app.get('/friends')
+def friends():
+    token = request.args.get('token', '')
+    return jsonify({'friends': ['friend1', 'friend2']})
+
+@app.post('/dm')
+def dm():
+    data = request.get_json() or {}
+    return jsonify({'status': 'sent', 'to': data.get('to')}), 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+

--- a/tests/KillSwitchTests.cpp
+++ b/tests/KillSwitchTests.cpp
@@ -1,0 +1,19 @@
+#include <filesystem>
+#include <catch2/catch_test_macros.hpp>
+#include "KillSwitch.hpp"
+#include <fstream>
+#include <chrono>
+#include <thread>
+
+TEST_CASE("KillSwitch detects file", "[KillSwitch]") {
+    std::string path = "killswitch_test";
+    KillSwitch ks(path);
+    ks.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::ofstream(path).close();
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    REQUIRE(ks.triggered());
+    ks.stop();
+    std::filesystem::remove(path);
+}
+

--- a/tests/RateLimiterTests.cpp
+++ b/tests/RateLimiterTests.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include "RateLimiter.hpp"
+#include <chrono>
+
+TEST_CASE("RateLimiter enforces delay", "[RateLimiter]") {
+    RateLimiter limiter(2); // 2 ops per sec
+    auto start = std::chrono::steady_clock::now();
+    limiter.acquire();
+    limiter.acquire();
+    limiter.acquire();
+    auto dur = std::chrono::steady_clock::now() - start;
+    REQUIRE(dur >= std::chrono::milliseconds(1000));
+}
+

--- a/tests/TokenLoaderTests.cpp
+++ b/tests/TokenLoaderTests.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch_test_macros.hpp>
+#include "TokenLoader.hpp"
+#include <fstream>
+
+TEST_CASE("TokenLoader filters invalid tokens", "[TokenLoader]") {
+    std::ofstream file("test_tokens.txt");
+    file << "validtoken1\n";
+    file << "bad token\n";
+    file << "validtoken2\n";
+    file.close();
+
+    TokenLoader loader("test_tokens.txt");
+    auto tokens = loader.load();
+    REQUIRE(tokens.size() == 2);
+    std::remove("test_tokens.txt");
+}
+

--- a/tests/WormLogicTests.cpp
+++ b/tests/WormLogicTests.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include "WormLogic.hpp"
+#include "RateLimiter.hpp"
+#include "KillSwitch.hpp"
+
+TEST_CASE("WormLogic handles empty token list", "[WormLogic]") {
+    std::vector<std::string> tokens;
+    RateLimiter limiter(1);
+    KillSwitch ks("ks_test");
+    WormLogic worm(tokens, "http://localhost:5000", limiter, ks);
+    worm.run();
+    REQUIRE(true); // should not crash
+}
+

--- a/tokens.txt
+++ b/tokens.txt
@@ -1,0 +1,3 @@
+dummy_token_1
+dummy_token_2
+bad token


### PR DESCRIPTION
## Summary
- lay down C++17 Discord worm simulator with modular token loading, rate limiting, kill switch, and worm logic using local stub server
- add Dockerfile, stub Flask server, and example tokens for safe lab deployment
- include Catch2 unit tests for core modules and documentation/disclaimer

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build` *(pass)*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68914aff2ca08321a27f9e5a276c8694